### PR TITLE
Fix support for multi-material meshes

### DIFF
--- a/src/CSG.ts
+++ b/src/CSG.ts
@@ -30,6 +30,7 @@ export class CSG {
     const normalattr = geom.attributes.normal;
     const uvattr = geom.attributes.uv;
     const colorattr = geom.attributes.color;
+    const grps = geom.groups;
     let index;
 
     if (geom.index) {
@@ -70,7 +71,15 @@ export class CSG {
         );
       }
 
-      polys[pli] = new Polygon(vertices, objectIndex);
+      if (objectIndex === undefined) {
+        for (const grp of grps) {
+          if (index[i] >= grp.start && index[i] < grp.start + grp.count) {
+            polys[pli] = new Polygon(vertices, grp.materialIndex);
+          }
+        }
+      } else {
+        polys[pli] = new Polygon(vertices, objectIndex);
+      }
     }
 
     return CSG.fromPolygons(polys);
@@ -125,6 +134,11 @@ export class CSG {
     geom.setAttribute('normal', new BufferAttribute(normals.array, 3));
     geom.setAttribute('uv', new BufferAttribute(uvs.array, 2));
     colors && geom.setAttribute('color', new BufferAttribute(colors.array, 3));
+    for (let gi = 0; gi < grps.length; gi++) {
+      if (grps[gi] === undefined) {
+        grps[gi] = [];
+      }
+    }
     if (grps.length) {
       let index = [];
       let gbase = 0;


### PR DESCRIPTION
Hello !

I introduced a while ago in #15 support for multi-material meshes (issue #12).

Unfortunately, following support for three.js v>=0.125, my code got outdated and removed. The support of multi-material meshes is currently broken.

Here is a suggested fix, tested on my own project and working fine.

It takes advantage of the optional `objectIndex` argument already in the original library from Mandrax which is only partially working. Actually the process of recreating the group geometries from the shared `objectIndex` is working (except a bug in some situations which I fixed), but the process of storing this `objectIndex` in the polygons is wrong, in my opinion.

I haven't been able to understand what kind of type is supposed to be fed as `objectIndex`, but from the (correct) implementation of the recreation of the groups, it is supposed to be a number. But if you feed a number to `fromGeometry` (for instance), it means that all the polygons will have the same `objectIndex`, which is obviously wrong. 

So what I did is to keep the current functionality of `objectIndex` for people using it (i.e. when the optional `objectIndex` is given by the caller) and for others I implemented the fix which takes the materialIndex of the first vertex of the face as `objectIndex`.

Okey for you @samalexander ? Let me know if anything is not clear.