### PR TITLE
Fix polygons creation for geometries without groups

### DIFF
--- a/src/CSG.ts
+++ b/src/CSG.ts
@@ -71,7 +71,7 @@ export class CSG {
         );
       }
 
-      if (objectIndex === undefined) {
+      if (objectIndex === undefined && grps && grps.length > 0) {
         for (const grp of grps) {
           if (index[i] >= grp.start && index[i] < grp.start + grp.count) {
             polys[pli] = new Polygon(vertices, grp.materialIndex);


### PR DESCRIPTION
Good morning, 

Me again... 

Thanks @samalexander for merging my PR (#27). I noticed that my code might not be very robust in case a geometry doesn't have any group. Apparently a three.js geometry can have an empty `groups` array. I personally think that a geometry should always have at least one group (like they do with `drawRange`: `{ start: 0, count: Infinity }`), but this is up to three.js...

So here is a fix which adds a check on the length of the `groups` array, thus creating a `Polygon` like before, when `objectIndex` is not given and the geometry doesn't have any group.

Sorry for not thinking about this earlier...