### PR TITLE
fix: fallback to polygon with no objectIndex

### DIFF
--- a/src/CSG.ts
+++ b/src/CSG.ts
@@ -75,6 +75,8 @@ export class CSG {
         for (const grp of grps) {
           if (index[i] >= grp.start && index[i] < grp.start + grp.count) {
             polys[pli] = new Polygon(vertices, grp.materialIndex);
+          } else {
+            polys[pli] = new Polygon(vertices, undefined);
           }
         }
       } else {


### PR DESCRIPTION
So, turns out that the issue described in #32 is caused by spheres failing this check added in https://github.com/Jiro-Digital/three-csg-ts/pull/27: https://github.com/Jiro-Digital/three-csg-ts/blob/70b6258138e513719b563dc8bfb326e379d0a7d4/src/CSG.ts#L76

Currently, this means that no Polygon is created for those vertices, which is obviously not right. Adding a fallback that creates a Polygon with undefined objectIndex seems to solve the issue.