### PR TITLE
Fix finding group by index.

### DIFF
--- a/src/CSG.ts
+++ b/src/CSG.ts
@@ -73,7 +73,7 @@ export class CSG {
 
       if (objectIndex === undefined && grps && grps.length > 0) {
         for (const grp of grps) {
-          if (index[i] >= grp.start && index[i] < grp.start + grp.count) {
+          if (i >= grp.start && i < grp.start + grp.count) {
             polys[pli] = new Polygon(vertices, grp.materialIndex);
           }
         }


### PR DESCRIPTION
Multi-material support doesn't work on geometry with indexes.
I think it works for non-indexed geometries because `index[i] = i` in that case.

Since start and count in the case of indexes is the index of the index array, not the positions, `index[i]` should be replaced by `i`  in the check. 